### PR TITLE
add local planning instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Planning
+
+Repository-specific plan guidance lives in [docs/plans/README.md](docs/plans/README.md).
+
+- Track work in `docs/plans/<feature>/PLAN.md`.
+- Use a stable human-readable slug for `<feature>` by default.
+- If the human explicitly mentions a ticket or requests ticket-based naming, include the ticket in the directory name.
+- Treat `docs/plans/<feature>/PLAN.md` as the only live planning document for that work.
+- Start each feature by committing its `PLAN.md` first, before implementation commits.
+- Keep implementation commits atomic and aligned to the plan.
+- In each atomic implementation commit, update `docs/plans/<feature>/PLAN.md` so it is clear which task or finding that commit completed.
+- Update `Tasks` and `Notes / Findings` in place while executing.
+- Do not change `Goal` or `Exit Criteria` without human approval.
+
+## Working On Code
+
+- Do not include machine-specific absolute filesystem paths in checked-in files; prefer repository-relative paths and links when applicable.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,70 @@
+# Planning Layout
+
+This repository tracks work in a single live document per feature:
+
+`docs/plans/<feature>/PLAN.md`
+
+That `PLAN.md` is both the design record and the execution board. Supporting files are allowed, but this is the only live execution tracker for the work.
+
+## Feature Directory Naming
+
+Use a stable human-readable slug for `<feature>` by default:
+
+- `docs/plans/js-bitcount-alignment/PLAN.md`
+- `docs/plans/benchmark-refresh/PLAN.md`
+
+If the human explicitly mentions a ticket or wants ticket-based naming, include it in the directory name:
+
+- `docs/plans/123-js-bitcount-alignment/PLAN.md`
+
+## Plan Ownership
+
+Each feature `PLAN.md` is a live document.
+
+- The first commit for a feature should add its `PLAN.md`.
+- Subsequent implementation commits should be atomic and each should update the same `PLAN.md` to reflect the slice of work completed in that commit.
+- Agents should update `Tasks` and `Notes / Findings` while executing work.
+- `Goal` and `Exit Criteria` are human-owned sections.
+- Agents must not rewrite `Goal` or `Exit Criteria` without human approval.
+
+## Default `PLAN.md` Shape
+
+Use this structure unless the human asks for something else:
+
+```md
+# <Plan title>
+
+Status: proposed | in_progress | done
+
+## Goal
+
+What should exist when this work is complete.
+
+## Exit Criteria
+
+- Observable condition that proves the work is complete
+- Observable condition that proves the work is complete
+
+## Context
+
+Relevant background, constraints, and links.
+
+## Tasks
+
+- [ ] Concrete task
+- [ ] Concrete task
+
+## Notes / Findings
+
+- Decision, discovery, blocker, or follow-up worth preserving during execution.
+```
+
+## Extra Files
+
+Add extra files next to a feature `PLAN.md` only when the work actually needs them, for example:
+
+- `research.md`
+- `notes.md`
+- `decisions.md`
+
+Those files support the feature plan, but `docs/plans/<feature>/PLAN.md` remains the only live tracking document.


### PR DESCRIPTION
## Why

This repository did not have repo-local guidance for planning-oriented work or a checked-in rule against machine-specific absolute paths. Adding these files makes the expected workflow explicit so future changes are tracked consistently, implementation commits stay aligned to a live plan, and checked-in documentation stays portable across machines.

For `bitcount`, that matters because even small package changes can span implementation, tests, benchmarks, and release-facing updates. A single documented planning flow reduces ambiguity about where work should be tracked and how partial progress should be recorded, and the path rule helps avoid leaking local filesystem assumptions into repository files.

## What Changed

- added `AGENTS.md` with two repository-specific sections:
  - `Planning`, which points contributors to `docs/plans/README.md` and defines how feature work should be tracked in `docs/plans/<feature>/PLAN.md`
  - `Working On Code`, which explicitly forbids machine-specific absolute filesystem paths in checked-in files and prefers repository-relative paths and links
- added `docs/plans/README.md` describing the plan layout and ownership rules for `docs/plans/<feature>/PLAN.md`
- used `bitcount`-appropriate example feature names in the planning guide
- kept plan path examples repo-relative (`docs/plans/...`) so the guidance matches this repository structure

## Impact

Future contributors and agents now have a clear, repository-local convention for multi-step work and a checked-in rule that keeps file references portable. That should make feature execution more consistent and reduce accidental local-path leakage in documentation or instructions.