### PR TITLE
Modernize package and CI for Dart 3

### DIFF
--- a/.github/workflows/test-and-analyze.yaml
+++ b/.github/workflows/test-and-analyze.yaml
@@ -2,8 +2,12 @@ name: Test and Analyze
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 0 * * MON'
+
+permissions:
+  contents: read
 
 jobs:
   test-and-analyze:
@@ -12,15 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         sdk:
-          - 2.12.0 # min
+          - 3.7.0 # min
           - stable # max
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.sdk }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
 
       - name: Install dependencies
         run: dart pub get
@@ -32,4 +38,16 @@ jobs:
         run: dart analyze
 
       - name: Run tests
-        run: dart test
+        run: dart test -p vm,node
+
+      - name: Run example
+        run: dart run example/example.dart
+
+      - name: Downgrade dependencies
+        run: dart pub downgrade
+
+      - name: Analyze downgraded dependency resolution
+        run: dart analyze
+
+      - name: Run downgraded tests
+        run: dart test -p vm,node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+* modernized the package for Dart 3 with `sdk: ^3.7.0`.
+* replaced `pedantic` with `lints`.
+* refreshed dev dependency constraints for current Dart 3-compatible releases.
+* updated CI to run on pull requests, validate Dart `3.7.0` and stable, and
+  exercise both VM and Node test platforms including downgraded dependencies.
+
 ## [0.3.0] - 2021-11-16
 
 ### Added

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml

--- a/docs/plans/dart-3-modernization/PLAN.md
+++ b/docs/plans/dart-3-modernization/PLAN.md
@@ -1,6 +1,6 @@
 # Dart 3 Modernization
 
-Status: in_progress
+Status: done
 
 ## Goal
 
@@ -23,10 +23,10 @@ CI while preserving the public API and the VM/JS implementation split.
 
 - [x] Update package metadata for Dart 3 support and refresh dev dependencies.
 - [x] Replace `pedantic` with `lints` and address any compatibility changes.
-- [ ] Modernize the GitHub Actions workflow for current actions and CI coverage.
-- [ ] Validate latest and downgraded dependency flows on Dart `3.7.0` and
+- [x] Modernize the GitHub Actions workflow for current actions and CI coverage.
+- [x] Validate latest and downgraded dependency flows on Dart `3.7.0` and
       stable.
-- [ ] Validate formatting, analysis, tests, and example execution on Dart
+- [x] Validate formatting, analysis, tests, and example execution on Dart
       `3.7.0` and stable.
 
 ## Notes / Findings
@@ -35,5 +35,9 @@ CI while preserving the public API and the VM/JS implementation split.
   current test toolchain under downgraded VM resolution.
 - Reliable downgraded validation requires `test: ^1.31.0` together with the
   explicit `frontend_server_client: ^4.0.0` floor.
+- Explicit direct anchors for `file`, `pub_semver`, and `watcher` are not
+  required; downgraded analysis and tests remain green without them.
+- CI now runs on `push`, `pull_request`, and the weekly schedule, validates
+  Dart `3.7.0` and `stable`, and exercises `dart test -p vm,node`.
 - The `lints` migration required only small naming cleanups, and the package
   metadata now includes a `repository` field alongside the existing homepage.

--- a/docs/plans/dart-3-modernization/PLAN.md
+++ b/docs/plans/dart-3-modernization/PLAN.md
@@ -1,6 +1,6 @@
 # Dart 3 Modernization
 
-Status: proposed
+Status: in_progress
 
 ## Goal
 
@@ -8,10 +8,10 @@ Modernize the package to Dart 3 standards and make CI execute correctly.
 
 ## Exit Criteria
 
-- The package resolves, analyzes, and passes tests with `environment.sdk: ^3.0.0`.
-- CI passes on Dart `3.0.0` and on the current stable Dart SDK.
+- The package resolves, analyzes, and passes tests with `environment.sdk: ^3.7.0`.
+- CI passes on Dart `3.7.0` and on the current stable Dart SDK.
 - CI explicitly exercises both the VM and Node test platforms.
-- Stable CI also verifies downgraded dependency resolution and test execution.
+- CI also verifies downgraded dependency resolution and test execution.
 
 ## Context
 
@@ -21,14 +21,19 @@ CI while preserving the public API and the VM/JS implementation split.
 
 ## Tasks
 
-- [ ] Update package metadata for Dart 3 support and refresh dev dependencies.
-- [ ] Replace `pedantic` with `lints` and address any compatibility changes.
+- [x] Update package metadata for Dart 3 support and refresh dev dependencies.
+- [x] Replace `pedantic` with `lints` and address any compatibility changes.
 - [ ] Modernize the GitHub Actions workflow for current actions and CI coverage.
-- [ ] Validate latest and downgraded dependency flows on stable Dart.
-- [ ] Validate formatting, analysis, tests, and example execution on Dart `3.0.0`
-      and stable.
+- [ ] Validate latest and downgraded dependency flows on Dart `3.7.0` and
+      stable.
+- [ ] Validate formatting, analysis, tests, and example execution on Dart
+      `3.7.0` and stable.
 
 ## Notes / Findings
 
-- Planned SDK floor is `^3.0.0` rather than latest-stable-only.
-- Dependency selections must remain compatible with Dart `3.0.0`.
+- Final SDK floor is `^3.7.0`; lower floors did not validate cleanly with the
+  current test toolchain under downgraded VM resolution.
+- Reliable downgraded validation requires `test: ^1.31.0` together with the
+  explicit `frontend_server_client: ^4.0.0` floor.
+- The `lints` migration required only small naming cleanups, and the package
+  metadata now includes a `repository` field alongside the existing homepage.

--- a/docs/plans/dart-3-modernization/PLAN.md
+++ b/docs/plans/dart-3-modernization/PLAN.md
@@ -1,0 +1,34 @@
+# Dart 3 Modernization
+
+Status: proposed
+
+## Goal
+
+Modernize the package to Dart 3 standards and make CI execute correctly.
+
+## Exit Criteria
+
+- The package resolves, analyzes, and passes tests with `environment.sdk: ^3.0.0`.
+- CI passes on Dart `3.0.0` and on the current stable Dart SDK.
+- CI explicitly exercises both the VM and Node test platforms.
+- Stable CI also verifies downgraded dependency resolution and test execution.
+
+## Context
+
+This package currently targets Dart `>=2.12.0 <3.0.0`, uses `pedantic`, and has
+an older GitHub Actions workflow. The work should modernize package metadata and
+CI while preserving the public API and the VM/JS implementation split.
+
+## Tasks
+
+- [ ] Update package metadata for Dart 3 support and refresh dev dependencies.
+- [ ] Replace `pedantic` with `lints` and address any compatibility changes.
+- [ ] Modernize the GitHub Actions workflow for current actions and CI coverage.
+- [ ] Validate latest and downgraded dependency flows on stable Dart.
+- [ ] Validate formatting, analysis, tests, and example execution on Dart `3.0.0`
+      and stable.
+
+## Notes / Findings
+
+- Planned SDK floor is `^3.0.0` rather than latest-stable-only.
+- Dependency selections must remain compatible with Dart `3.0.0`.

--- a/lib/bitcount.dart
+++ b/lib/bitcount.dart
@@ -1,12 +1,11 @@
 import 'package:bitcount/src/native.dart'
-    if (dart.library.js) 'package:bitcount/src/js.dart' as _impl;
+    if (dart.library.js) 'package:bitcount/src/js.dart'
+    as impl;
 
 /// Extends [int] with [bitCount] method that returns number of one-bits.
 extension BitCountInt on int {
   /// Returns number of one-bits.
   ///
   /// NOTE: in JS is safe to use with up to 53 bits. See [int].
-  int bitCount() {
-    return _impl.bitCount(this);
-  }
+  int bitCount() => impl.bitCount(this);
 }

--- a/lib/src/js.dart
+++ b/lib/src/js.dart
@@ -1,4 +1,4 @@
-const _30Bits = (1 << 30);
+const thirtyBits = (1 << 30);
 
 // Described in Hacker's Delight (Figure 5-2).
 int _bitCount32(int n) {
@@ -11,7 +11,7 @@ int _bitCount32(int n) {
 }
 
 int bitCount(int n) {
-  var lo30Bits = n & (_30Bits - 1);
-  var hi22Bits = (n - lo30Bits) ~/ _30Bits;
+  var lo30Bits = n & (thirtyBits - 1);
+  var hi22Bits = (n - lo30Bits) ~/ thirtyBits;
   return _bitCount32(lo30Bits) + _bitCount32(hi22Bits);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,15 @@
 name: bitcount
-version: 0.3.0
+version: 0.4.0
 description: >-
   Provides efficient one-bits count method extension for default int.
 homepage: https://github.com/akhomchenko/bitcount
+repository: https://github.com/akhomchenko/bitcount
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ^3.7.0
 
 dev_dependencies:
-  test: ^1.16.8
-  pedantic: ^1.11.0
-  benchmark_harness: ^2.0.0
+  test: ^1.31.0
+  lints: ^5.1.1
+  benchmark_harness: ^2.3.1
+  frontend_server_client: ^4.0.0


### PR DESCRIPTION
## Why

This package still targeted pre-Dart-3 SDKs, used `pedantic`, and relied on an older GitHub Actions workflow. This PR modernizes the package and CI for Dart 3 while keeping the declared support floor honest: earlier lower-floor attempts did not hold up under downgraded VM test resolution, so the branch now uses the lowest floor that validates cleanly with the current test toolchain.

## What changed

- raised the package SDK constraint to `^3.7.0` and kept the pending package version at `0.4.0`
- replaced `pedantic` with `lints` and adjusted the small analyzer-driven naming issues surfaced by the newer lint set
- refreshed dev dependency constraints, including `test: ^1.31.0`
- added an explicit direct `frontend_server_client: ^4.0.0` floor so downgraded VM tests do not fall back to an older broken frontend-server client
- dropped unnecessary direct lower-bound anchors for `file`, `pub_semver`, and `watcher` after confirming downgraded analysis and tests still pass without them
- kept the changelog entry under `Unreleased`
- modernized CI to use current GitHub Actions versions, run on `push`, `pull_request`, and the weekly schedule, and exercise both `vm` and `node`
- validated both latest and downgraded dependency resolution on Dart `3.7.0` and current stable Dart

## Notes

The direct `frontend_server_client: ^4.0.0` constraint is intentional. Without it, downgraded resolution pulled an older frontend server client through `test_core`, and downgraded VM tests failed while loading test suites even though the package code itself was fine.

The current branch is green in GitHub Actions for both `3.7.0` and `stable` on normal and downgraded test paths.
